### PR TITLE
Added toJSON method

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -109,6 +109,16 @@
   };
 
   /**
+   * Returns a JSON representation of all the models in the index
+   * @return {Array} JSON models
+   */
+  vc.toJSON = function() {
+    return _.map(this._models(), function(model) {
+      return model.toJSON();
+    });
+  };
+
+  /**
    * Sorts the models in the virtual collection
    *
    * You only need to trigger this manually if you change the comparator

--- a/test/spec.js
+++ b/test/spec.js
@@ -252,6 +252,24 @@ describe('Backbone.VirtualCollection', function () {
     });
   });
 
+  describe('toJSON', function() {
+    it('should return a JSON representation of the models of the virtual collection', function() {
+      var collection = new Backbone.Collection([
+        {age: 23, name: 'John'},
+        {age: 44, name: 'Papa'},
+        {age: 44, name: 'Terry'}
+      ]);
+      vc = new VirtualCollection(collection, {
+        filter: {age: 44}
+      });
+
+      assert.deepEqual(vc.toJSON(), [
+        {age: 44, name: 'Papa'},
+        {age: 44, name: 'Terry'}
+      ]);
+    });
+  });
+
   describe('buildFilterFromHash', function () {
 
     it('should build an filter that accepts one correct attribute', function () {


### PR DESCRIPTION
The reason for this is that `Marionette.ItemView`'s `serializeData` falls back on `this.collection.toJSON` if a model cannot be found in the instance, as you can see [here](https://github.com/marionettejs/backbone.marionette/blob/master/lib/backbone.marionette.js#L1404).

Tell me what you think!
