### PR TITLE
Extend VirtualCollection from Backbone.Collection

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -79,7 +79,7 @@
   // hide all Backbone.Collection properties
   var property;
   for (property in Backbone.Collection.prototype) {
-      vc.property = undefined;
+      vc[property] = undefined;
   }
 
   // mix in Underscore method as proxies

--- a/test/spec.js
+++ b/test/spec.js
@@ -28,9 +28,13 @@ describe('Backbone.VirtualCollection', function () {
     });
 
     it ("should hide Backbone.Collection methods", function () {
-        var vc, collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
-        vc = new VirtualCollection(collection);
-        assert.ok(typeof vc.function === "undefined");
+        var bc = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
+        var vc = new VirtualCollection(bc);
+        var hidden = ["fetch", "sync"];
+        _.each(hidden, function(method) {
+            assert.ok(_.isFunction(bc[method]), "Backbone.Collection has function " + method);
+            assert.ok(typeof vc[method] === "undefined", "Backbone.VirtualCollection hides " + method);
+        });
     });
 
   });


### PR DESCRIPTION
Hello,

This PR makes it possible to use a VirtualCollection as if it were a Backbone.Collection in the case where some client code uses `instanceof Backbone.Collection` as part of its logic to check for collections.  

(For example, http://dhruvaray.github.io/backbone-associations provides "fully qualified paths" such as `emp.get('works_for.controls[0].locations[0].zip')` -- for each component of the path it checks `instanceof Backbone.Collection` to know whether to expect an index)

The PR is pretty trivial in terms of code change, it just extends from `Backbone.Collection`, and moves the existing constructor code into a `constructor` field (so most of the changes are just indentation fallout).  There's no attempt to either inherit nor suppress behavior provided by `Backbone.Collection`.

I've verified that the test suite passes, and I've tried it out in my own application, and all seems good.   I'll admit though that I haven't thought through whether there are any deep or subtle issues that'd arise from this.
