### PR TITLE
Improve performance

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -42,7 +42,7 @@
 
     _.bindAll(this, 'each', 'map', 'get', 'at', 'indexOf', 'sort', 'closeWith',
      '_rebuildIndex', '_models', '_onAdd', '_onRemove', '_onChange', '_onReset',
-     '_indexAdd', '_indexRemove', '_getFromIndex');
+     '_indexAdd', '_indexRemove');
 
     // set filter
     this.filterFunction = VirtualCollection.buildFilter(options.filter);
@@ -104,25 +104,26 @@
 
   /**
    * Returns a model if it belongs to the virtual collection
-   * @param  {String} id
+   * @param  {String} id or cid
    * @return {Model}
    */
   vc.get = function (id) {
-    var model = this.collection.get(id);
+    var model = this._getParentCollection().get(id);
     if (model && _.contains(this.index, model.cid)) {
       return model;
     }
   };
 
   /**
-   * Returns a model from a collection without checking if
-   * it is contained in the index. Used when looping
-   * the index itself.
-   * @param {String} id
-   * @return {Model}
+   * Returns the parent non-virtual collection.
+   * @return {Collection}
    */
-  vc._getFromIndex = function (id) {
-    return this.collection.get(id);
+  vc._getParentCollection = function () {
+    if (this.collection instanceof VirtualCollection) {
+      return this.collection._getParentCollection();
+    } else {
+      return this.collection;
+    }
   };
 
   /**
@@ -245,9 +246,9 @@
    * @return {Array}
    */
   vc._models = function () {
-    var getFn = this.collection instanceof VirtualCollection ? '_getFromIndex' : 'get';
+    var parentCollection = this._getParentCollection();
     return _.map(this.index, function (cid) {
-      return this.collection[getFn](cid);
+      return parentCollection.get(cid);
     }, this);
   };
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -485,8 +485,6 @@ describe('Backbone.VirtualCollection', function () {
       });
 
       sinon.spy(vc, 'filterFunction');
-      sinon.spy(vc, 'get');
-      sinon.spy(vc, '_getFromIndex');
 
       vc.each(function(model) {
         //looping collection
@@ -511,29 +509,17 @@ describe('Backbone.VirtualCollection', function () {
       });
 
       sinon.spy(collection, 'get');
-
       sinon.spy(vc, 'get');
-      sinon.spy(vc, '_getFromIndex');
-
       sinon.spy(daddy_vc, 'get');
-      sinon.spy(daddy_vc, '_getFromIndex');
-
       sinon.spy(grandpa_vc, 'get');
-      sinon.spy(grandpa_vc, '_getFromIndex');
 
       vc.each(function(model) {
         //looping collection
       });
 
       assert(!vc.get.called);
-      assert(!vc._getFromIndex.called);
-
       assert(!daddy_vc.get.called);
-      assert(daddy_vc._getFromIndex.called);
-
       assert(!grandpa_vc.get.called);
-      assert(grandpa_vc._getFromIndex.called);
-
       assert(collection.get.called);
     });
 


### PR DESCRIPTION
Don't check if the model is in the index when iterating through `_models`.

Also, access Backbone parent collection directly when returning `_models`, even with multiple nested virtual collections.
