### PR TITLE
Add the `extend` function to VirtualCollection

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -389,6 +389,8 @@
   };
 
   _.extend(vc, Backbone.Events);
+  
+  VirtualCollection.extend = Backbone.Collection.extend;
 
   Backbone.VirtualCollection = VirtualCollection;
 


### PR DESCRIPTION
So that we can create subclasses, the way we do for Backbone models / collections / views:

<pre>
    var Subset_Collection_Appointment = Backbone.VirtualCollection.extend({
        filter_by_doctor: function(doctor) {
            this.updateFilter(function(appointment) {
                return appointment.get('doctor').id == doctor.id;
            });
        }
    });
</pre>


References:
https://github.com/jashkenas/backbone/blob/master/backbone.js#L1655
https://github.com/jashkenas/backbone/blob/master/backbone.js#L1689

https://github.com/masylum/Backbone.Subset/blob/master/backbone.subset.js#L361

Thank you :)
