### PR TITLE
remove model.id and model.cid in _indexRemove()

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -113,6 +113,8 @@ var VirtualCollection = Backbone.Collection.extend({
     var i = this.indexOf(model);
     if (i !== -1) {
       this.models.splice(i, 1);
+      delete this._byId[model.cid];
+      if (model.id) delete this._byId[model.id];
       this.length = this.models.length;
     }
     return i;


### PR DESCRIPTION
Untested, but surely we want this to mirror `_indexAdd`, no?  Seems like a memory leak and cause for inaccurate membership tests...

Also, what about changes to the model's id?  I don't have time to look into this at present, but IIRC Backbone has some special handling of this scenario.  I'll take a closer look later this evening and make sure this case is covered...
