### PR TITLE
some spelling/grammar/consistency/clarity tweaks

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -19,7 +19,7 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#constructor', function () {
 
-    it("should bind 4 listeners to it's collection", function () {
+    it('should bind 4 listeners to its collection', function () {
       var vc, calls, collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
       sinon.spy(collection, 'on');
       vc = new VirtualCollection(collection);
@@ -27,7 +27,7 @@ describe('Backbone.VirtualCollection', function () {
       assert.equal(calls, JSON.stringify([ 'add', 'remove', 'change', 'reset' ]));
     });
 
-    it('should build an index on instanciation', function () {
+    it('should build an index on instantiation', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, foo: 'bar'},
         {id: 2, foo: 'baz'},
@@ -39,7 +39,7 @@ describe('Backbone.VirtualCollection', function () {
       assert.equal(vc.models.length, 2);
     });
 
-    it("should accept a close_with option and bind close event", function () {
+    it('should accept a close_with option and bind to the `close` event', function () {
       var vc, calls, collection, event_emitter;
       collection = new Backbone.Collection([{id: 1, foo: 'bar'}]);
       event_emitter = Backbone.Events;
@@ -52,7 +52,7 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#model', function () {
 
-    it("should inherit the parent collection type model", function () {
+    it('should inherit the model type of the parent collection', function () {
       var vc, collection, Library;
 
       Library = Backbone.Collection.extend({
@@ -68,7 +68,7 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#each', function () {
 
-    it('should iterate over the index in order', function () {
+    it('should iterate over the virtual collection in order', function () {
       var vc, result = [], collection = new Backbone.Collection([
         {id: 1, foo: 'bar'},
         {id: 2, foo: 'baz'},
@@ -86,7 +86,7 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#indexOf', function () {
 
-    it('should return the index of a model within the virtual collection, not the parent collection', function () {
+    it('should return the index of a model as ordered in the virtual collection', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, foo: 'bar'},
         {id: 2, foo: 'baz'},
@@ -100,7 +100,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('#where', function () {
-    it('finds all the models matching attributes', function () {
+    it('finds all the models matching the given attributes', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, foo: 'bar'},
         {id: 2, foo: 'baz'},
@@ -112,7 +112,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('#findWhere', function () {
-    it('finds the first model matching attributes', function () {
+    it('finds the first model matching the given attributes', function () {
       var vc, collection = new Backbone.Collection([
         {id: 10, foo: 'bar'},
         {id: 20, foo: 'baz'},
@@ -134,7 +134,7 @@ describe('Backbone.VirtualCollection', function () {
       assert.deepEqual(vc.pluck('id'), [10, 30]);
     });
 
-    it('returns an array of field values', function () {
+    it('returns an array of attribute values', function () {
       var vc, collection = new Backbone.Collection([
         {id: 10, foo: 'bar'},
         {id: 20, foo: 'baz'},
@@ -146,24 +146,25 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('#_addIndex', function () {
-    it('should use comparators to insert the model at the right place in the index', function () {
+    it('should use comparators to correctly order the model in the virtual collection', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, ok: true,  foo: 'ccc'},
         {id: 2, ok: false, foo: 'bbb'},
         {id: 3, ok: true,  foo: 'aaa'}
       ], {
-        comparator: 'foo' // shortBy foo
+        comparator: 'foo' // sortBy foo attribute
       });
       vc = new VirtualCollection(collection, {
         filter: {ok: true}
       });
       collection.add({id: 4, ok: true, foo: 'abc'});
+      assert.deepEqual(collection.pluck('id'), [3,4,2,1]);
       assert.deepEqual(vc.pluck('id'), [3,4,1]);
     });
   });
 
   describe('#comparator', function () {
-    it('should sort the index on instanciation', function () {
+    it('should sort the virtual collection upon instantiation', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, name: 'ccc'},
         {id: 2, name: 'aaa'},
@@ -177,7 +178,7 @@ describe('Backbone.VirtualCollection', function () {
       });
       assert.deepEqual(vc.pluck('id'), [2, 3, 1]);
     });
-    it('should accept comparator function', function () {
+    it('should accept a comparator()', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, name: 'ccc'},
         {id: 2, name: 'aaa'},
@@ -191,7 +192,7 @@ describe('Backbone.VirtualCollection', function () {
       });
       assert.deepEqual(vc.pluck('id'), [2, 3, 1]);
     });
-    it('should accept a comparator function that compares two models', function () {
+    it('should accept a comparator() that compares two models', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, name: 'ccc'},
         {id: 2, name: 'aaa'},
@@ -206,7 +207,7 @@ describe('Backbone.VirtualCollection', function () {
       });
       assert.deepEqual(vc.pluck('id'), [1, 3, 2]);
     });
-    it('should keep the index sorted when adding items', function () {
+    it('should keep the virtual collection sorted when adding items', function () {
       var vc, collection = new Backbone.Collection([
         {id: 1, name: 'ccc'},
         {id: 3, name: 'bbb'}
@@ -221,7 +222,7 @@ describe('Backbone.VirtualCollection', function () {
       assert.deepEqual(vc.pluck('id'), [2, 3, 1]);
     });
 
-    it('should update the index when reset is triggered on the parent collection', function () {
+    it('should update the virtual collection when a `reset` event is triggered by the parent collection', function () {
       var collection = new Backbone.Collection([
         {type: 'a'},
         {type: 'a'},
@@ -239,7 +240,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('closeWith', function () {
-    it('should clear the collections listenters when the view is closed', function () {
+    it('should clear the virtual collection\'s listeners when the view is closed', function () {
       var collection = new Backbone.Collection([
         {id: 1, name: 'ccc'},
         {id: 2, name: 'bbb'},
@@ -256,7 +257,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('map', function () {
-    it('should map over the virtual collections model array', function () {
+    it('should map the models in the virtual collection', function () {
       var collection = new Backbone.Collection([
         {type: 'a', name: 'hodor'},
         {type: 'a', name: 'khalesi'},
@@ -270,7 +271,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('each', function () {
-    it('should interate over the models', function () {
+    it('should iterate over the models in the virtual collection', function () {
       var collection = new Backbone.Collection([
         {type: 'a', name: 'hodor'},
         {type: 'a', name: 'khalesi'},
@@ -314,7 +315,7 @@ describe('Backbone.VirtualCollection', function () {
   });
 
   describe('toJSON', function() {
-    it('should return a JSON representation of the models of the virtual collection', function() {
+    it('should return a JSON representation of the models in the virtual collection', function() {
       var collection = new Backbone.Collection([
         {age: 23, name: 'John'},
         {age: 44, name: 'Papa'},
@@ -342,8 +343,8 @@ describe('Backbone.VirtualCollection', function () {
     });
   });
 
-  describe('filter function', function () {
-    it('should recieve the model and index as arguments', function () {
+  describe('filter', function () {
+    it('should receive the model and index as arguments', function () {
       var i = 0,
       collection = new Backbone.Collection([{id: 1}, {id: 2}]);
 
@@ -360,33 +361,35 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('buildFilter', function () {
 
-    it('should build an filter that accepts one correct attribute', function () {
+    it('should build a single-attribute filter that matches a model', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar'});
       assert.equal(true, filter(new Backbone.Model({foo: 'bar'})));
     });
-    it('should build an filter that rejects one false attribute', function () {
+    it('should build a single-attribute filter that rejects a model', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar'});
       assert.equal(false, filter(new Backbone.Model({foo: 'car'})));
     });
-    it('should build an filter that accepts multiple correct attributes', function () {
+    it('should build a multiple-attribute filter that matches a model', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar', ginger: 'ale'});
       assert.equal(true, filter(new Backbone.Model({foo: 'bar', ginger: 'ale'})));
     });
-    it('should build an filter that rejects a missing attribute', function () {
+    it('should build a multiple-attribute filter that rejects a model', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar', ginger: 'ale'});
       assert.equal(false, filter(new Backbone.Model({foo: 'bar'})));
     });
-    it('should a build a filter that finds null values', function () {
+    it('should build a filter that matches model attributes with null values', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar', ginger: null});
       assert.equal(false, filter(new Backbone.Model({foo: 'bar', ginger: 'not null'})));
+      assert.equal(true, filter(new Backbone.Model({foo: 'bar', ginger: null})));
     });
-    it('should a build a filter that finds undefined values', function () {
+    it('should build a filter that matches model attributes with undefined values', function () {
       var filter = VirtualCollection.buildFilter({foo: 'bar', ginger: undefined});
       assert.equal(false, filter(new Backbone.Model({foo: 'bar', ginger: 'not null'})));
+      assert.equal(true, filter(new Backbone.Model({foo: 'bar', ginger: undefined})));
     });
   });
   describe('events', function () {
-    it('should trigger reset when the parent collection is reset', function () {
+    it('should trigger a `reset` event when the parent collection is reset', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -398,7 +401,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert.equal(vc.length, 2);
     });
-    it('should trigger add when a matching model is added to the parent', function () {
+    it('should trigger an `add` event when a matching model is added to the parent', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -410,7 +413,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert.equal(vc.length, 2);
     });
-    it('should not trigger add when a model (not matching) is added to the parent', function () {
+    it('should not trigger an `add` event when an unmatching model is added to the parent', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -422,7 +425,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(!called);
       assert.equal(vc.length, 1);
     });
-    it('should trigger remove when a matching model is removed from the parent', function () {
+    it('should trigger a `remove` event when a matching model is removed from the parent', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -434,7 +437,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert.equal(vc.length, 0);
     });
-    it('should not trigger remove when a model (not matching) is removed from the parent', function () {
+    it('should not trigger a `remove` event when an unmatching model is removed from the parent', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -447,7 +450,7 @@ describe('Backbone.VirtualCollection', function () {
       assert.equal(vc.length, 1);
     });
 
-    it('should trigger remove when a model no longer passes the filter', function () {
+    it('should trigger a `remove` event when a model no longer passes the filter', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -459,7 +462,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert(vc.length === 0);
     });
-    it('should trigger add when a model is modified to pass the filter', function () {
+    it('should trigger an `add` event when a modified model now passes the filter', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -471,7 +474,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert(vc.length === 2);
     });
-    it('should trigger change when a model that belongs to the VC is changed', function () {
+    it('should trigger a `change` event when a model in the virtual collection is changed', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
@@ -483,7 +486,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(called);
       assert(vc.length === 1);
     });
-    it('should trigger `filter` when updateFilter is called', function () {
+    it('should trigger a `filter` event when updateFilter() is called', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       filter = sinon.stub(),
       vc = new VirtualCollection(collection, {
@@ -496,7 +499,7 @@ describe('Backbone.VirtualCollection', function () {
       assert(filter.called);
       assert(vc.length === 1);
     });
-    it('should trigger `reset` when updateFilter is called', function () {
+    it('should trigger a `reset` event when updateFilter() is called', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       reset = sinon.stub(),
       vc = new VirtualCollection(collection, {
@@ -509,7 +512,9 @@ describe('Backbone.VirtualCollection', function () {
       assert(reset.called);
       assert(vc.length === 1);
     });
-    it('should not call the filter function when looping the collection', function () {
+  });
+  describe('accepts & get', function () {
+    it('should not call accepts() when iterating over the virtual collection', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
           filterFunction;
 
@@ -529,7 +534,7 @@ describe('Backbone.VirtualCollection', function () {
 
       assert(!vc.accepts.called);
     });
-    it('should not call `get` when looping multiple level nested virtual collections', function () {
+    it('should not call get() when iterating over nested virtual collections', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
           filterFunction;
 


### PR DESCRIPTION
I'm not sure how `sortIndex()` is supposed to work in v0.5; the Underscore version won't work in this test because it will be looking for a `foo` attribute of the `model` object, as opposed to an attribute of the `model.attributes` object.

Do you have an implementation of `sortIndex` which was somehow omitted from VirtualCollection?
