### PR TITLE
proxies now proxy the return the values of the parent methods as well

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -20,12 +20,12 @@ var VirtualCollection = Backbone.Collection.extend({
 
     this.accepts = VirtualCollection.buildFilter(options.filter);
     this._rebuildIndex();
-    this.initialize.apply(this, arguments);
-
     this.listenTo(this.collection, 'add', this._onAdd);
     this.listenTo(this.collection, 'remove', this._onRemove);
     this.listenTo(this.collection, 'change', this._onChange);
     this.listenTo(this.collection, 'reset',  this._onReset);
+
+    this.initialize.apply(this, arguments);
   },
 
   // marionette specific
@@ -137,11 +137,21 @@ var VirtualCollection = Backbone.Collection.extend({
   }
 });
 
+// mix in additional Underscore methods
+var slice = [].slice;
+_.each(['sortedIndex'], function(method) {
+  if (!_[method]) return;
+  VirtualCollection.prototype[method] = function() {
+    var args = slice.call(arguments);
+    args.unshift(this.models);
+    return _[method].apply(_, args);
+  };
+});
 
 // methods that alter data should proxy to the parent collection
 _.each(['add', 'remove', 'set', 'reset', 'push', 'pop', 'unshift', 'shift', 'slice', 'sync', 'fetch'], function (method_name) {
   VirtualCollection.prototype[method_name] = function () {
-    this.collection[method_name].apply(this.collection, _.toArray(arguments));
+    return this.collection[method_name].apply(this.collection, _.toArray(arguments));
   };
 });
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -337,7 +337,8 @@ describe('Backbone.VirtualCollection', function () {
       vc = new VirtualCollection(collection, {});
       vc.add({id: 2});
       assert.equal(collection.length, 1);
-      vc.remove(collection.at(0));
+      model = vc.remove(collection.at(0));
+      assert(model.id == 2);
       assert.equal(collection.length, 0);
     });
   });


### PR DESCRIPTION
I added the Underscore `sortedIndex` so that it's possible to run more tests in the suite, including the one that prevents regression of this bug.  This also invokes the `initialize()` as the last step of the `constructor()` so that those extending VirtualCollection can rebind the events in `initialize()` should they so choose.
