### PR TITLE
Prevent explicitly handled events from being triggered twice

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -42,12 +42,12 @@ VirtualCollection = Backbone.Collection.extend({
 
   _rebuildIndex: function () {
     for(idx in this.models) {
-      this.models[idx].off('all', this._onModelEvent, this);
+      this.models[idx].off('all', this._onAllEvent, this);
     }
     this._reset();
     this.collection.each(function (model, i) {
       if (this.accepts(model, i)) {
-        model.on('all', this._onModelEvent, this);
+        model.on('all', this._onAllEvent, this);
         this.models.push(model);
         this._byId[model.cid] = model;
         if (model.id) this._byId[model.id] = model;
@@ -74,7 +74,7 @@ VirtualCollection = Backbone.Collection.extend({
     var already_here = this.get(model);
     if (!already_here && this.accepts(model, options.index)) {
       this._indexAdd(model);
-      model.on('all', this._onModelEvent, this);
+      model.on('all', this._onAllEvent, this);
       this.trigger('add', model, this, options);
     }
   },
@@ -85,7 +85,7 @@ VirtualCollection = Backbone.Collection.extend({
     var i = this._indexRemove(model)
     , options_clone = _.clone(options);
     options_clone.index = i;
-    model.off('all', this._onModelEvent, this);
+    model.off('all', this._onAllEvent, this);
     this.trigger('remove', model, this, options_clone);
   },
 
@@ -148,7 +148,7 @@ VirtualCollection = Backbone.Collection.extend({
   },
 
   _indexRemove: function (model) {
-    model.off('all', this._onModelEvent, this);
+    model.off('all', this._onAllEvent, this);
     var i = this.indexOf(model);
     if (i === -1) return i;
     this.models.splice(i, 1);
@@ -156,6 +156,13 @@ VirtualCollection = Backbone.Collection.extend({
     if (model.id) delete this._byId[model.id];
     this.length -= 1;
     return i;
+  },
+
+  _onAllEvent: function (eventName) {
+    var explicitlyHandledEvents = ['add', 'remove', 'change', 'reset', 'sort'];
+    if (!_.contains(explicitlyHandledEvents, eventName)) {
+      this.trigger.apply(this, arguments);
+    }
   }
 
 }, { // static props

--- a/test/spec.js
+++ b/test/spec.js
@@ -501,12 +501,13 @@ describe('Backbone.VirtualCollection', function () {
       var collection = new Backbone.Collection([{type: 'a'}, {type: 'b'}]),
       vc = new VirtualCollection(collection, {
         filter: {type: 'a'}
-      }), called = false;
+      }), changeSpy = sinon.spy();
 
-      vc.on('change', function () { called = true; });
+      vc.on('change', changeSpy);
       collection.at(0).set({foo: 'bar'});
 
-      assert(called);
+      assert(changeSpy.called);
+      assert(changeSpy.calledOnce);
       assert(vc.length === 1);
     });
     it('should trigger a `change:[attributeName]` event when a models attribute in the original collection is changed', function () {


### PR DESCRIPTION
A recent version of Backbone.VirtualCollection started proxying models' 'change' events
to the virtual collection [1]. Sadly this change introduced regression that caused
'change' events to be triggered twice.

[1] https://github.com/p3drosola/Backbone.VirtualCollection/commit/6d9f0e7c06245207f3f68a6c141795fe414ca018