### PR TITLE
Proxy sync event

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -23,6 +23,7 @@ VirtualCollection = Backbone.Collection.extend({
     this.listenTo(this.collection, 'change', this._onChange);
     this.listenTo(this.collection, 'reset',  this._onReset);
     this.listenTo(this.collection, 'sort',  this._onSort);
+    this.listenTo(this.collection, 'sync',  this._onSync);
 
     this.initialize.apply(this, arguments);
   },
@@ -68,6 +69,10 @@ VirtualCollection = Backbone.Collection.extend({
   _onSort: function (collection, options) {
     if (this.comparator !== undefined) return;
     this.orderViaParent(options);
+  },
+
+  _onSync: function (method, model, options) {
+    this.trigger('sync', method, model, options);
   },
 
   _onAdd: function (model, collection, options) {

--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -23,7 +23,7 @@ VirtualCollection = Backbone.Collection.extend({
     this.listenTo(this.collection, 'change', this._onChange);
     this.listenTo(this.collection, 'reset',  this._onReset);
     this.listenTo(this.collection, 'sort',  this._onSort);
-    this.listenTo(this.collection, 'sync',  this._onSync);
+    this._proxyParentEvents(['sync', 'request', 'error']);
 
     this.initialize.apply(this, arguments);
   },
@@ -71,8 +71,10 @@ VirtualCollection = Backbone.Collection.extend({
     this.orderViaParent(options);
   },
 
-  _onSync: function (method, model, options) {
-    this.trigger('sync', method, model, options);
+  _proxyParentEvents: function (events) {
+    _.each(events, function (eventName) {
+      this.listenTo(this.collection, eventName, _.partial(this.trigger, eventName));
+    }, this);
   },
 
   _onAdd: function (model, collection, options) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,12 +18,21 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#constructor', function () {
 
-    it('should bind 6 listeners to its collection', function () {
+    it('should bind 8 listeners to its collection', function () {
       var vc, calls, collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
       sinon.spy(collection, 'on');
       vc = new VirtualCollection(collection);
       calls = JSON.stringify(_.map(collection.on.args, function (i) {return i[0]; }));
-      assert.equal(calls, JSON.stringify([ 'add', 'remove', 'change', 'reset', 'sort', 'sync' ]));
+      assert.equal(calls , JSON.stringify([
+        'add',
+        'remove',
+        'change',
+        'reset',
+        'sort',
+        'sync',
+        'request',
+        'error'
+      ]));
     });
 
     it('should build an index on instantiation', function () {
@@ -351,19 +360,55 @@ describe('Backbone.VirtualCollection', function () {
     });
   });
 
-  describe('sync', function () {
+  describe('proxy parent events', function () {
     it('should proxy the sync event', function () {
       var collection = new Backbone.Collection([])
-        , syncSpy = sinon.spy();
+        , eventSpy = sinon.spy();
 
       vc = new VirtualCollection(collection, {});
-      vc.on('sync', syncSpy);
+      vc.on('sync', eventSpy);
 
       collection.trigger('sync');
 
-      assert(syncSpy.called);
+      assert(eventSpy.called);
     });
-  });
+
+    it('should proxy the request event', function () {
+      var collection = new Backbone.Collection([])
+        , eventSpy = sinon.spy();
+
+      vc = new VirtualCollection(collection, {});
+      vc.on('request', eventSpy);
+
+      collection.trigger('request');
+
+      assert(eventSpy.called);
+    });
+
+    it('should proxy the error event', function () {
+      var collection = new Backbone.Collection([])
+        , eventSpy = sinon.spy();
+
+      vc = new VirtualCollection(collection, {});
+      vc.on('error', eventSpy);
+
+      collection.trigger('error');
+
+      assert(eventSpy.called);
+    });
+
+    it('should proxy event arguments', function () {
+      var collection = new Backbone.Collection([])
+        , eventSpy = sinon.spy();
+
+      vc = new VirtualCollection(collection, {});
+      vc.on('error', eventSpy);
+
+      collection.trigger('error', 'foo', 'bar');
+
+      assert(eventSpy.calledWith('foo', 'bar'));
+    });
+   });
 
   describe('filter', function () {
     it('should receive the model and index as arguments', function () {

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,12 +18,12 @@ describe('Backbone.VirtualCollection', function () {
 
   describe('#constructor', function () {
 
-    it('should bind 4 listeners to its collection', function () {
+    it('should bind 6 listeners to its collection', function () {
       var vc, calls, collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
       sinon.spy(collection, 'on');
       vc = new VirtualCollection(collection);
       calls = JSON.stringify(_.map(collection.on.args, function (i) {return i[0]; }));
-      assert.equal(calls, JSON.stringify([ 'add', 'remove', 'change', 'reset', 'sort' ]));
+      assert.equal(calls, JSON.stringify([ 'add', 'remove', 'change', 'reset', 'sort', 'sync' ]));
     });
 
     it('should build an index on instantiation', function () {
@@ -348,6 +348,20 @@ describe('Backbone.VirtualCollection', function () {
       model = vc.remove(collection.at(0));
       assert(model.id == 2);
       assert.equal(collection.length, 0);
+    });
+  });
+
+  describe('sync', function () {
+    it('should proxy the sync event', function () {
+      var collection = new Backbone.Collection([])
+        , syncSpy = sinon.spy();
+
+      vc = new VirtualCollection(collection, {});
+      vc.on('sync', syncSpy);
+
+      collection.trigger('sync');
+
+      assert(syncSpy.called);
     });
   });
 


### PR DESCRIPTION
Proxy sync event from the parent collection.

Use case: Sometimes you want to listen to the sync event ( showing a loading view while the collection fetches, then rendering the actual collection view ), and this should work for both native and virtual collections.