### PR TITLE
Make sure you can find a model by ID if present

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -103,6 +103,10 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (!model || !options) return; // ignore malformed arguments coming from custom events
     var already_here = this.get(model);
 
+    if (!this._byId[model.id] && model.id) {
+      this._byId[model.id] = model;
+    }
+
     if (this.accepts(model, options.index)) {
       if (already_here) {
         this.trigger('change', model, this, options);

--- a/src/backbone.virtual-collection.js
+++ b/src/backbone.virtual-collection.js
@@ -94,6 +94,10 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (!model || !options) return; // ignore malformed arguments coming from custom events
     var already_here = this.get(model);
 
+    if (!this._byId[model.id] && model.id) {
+      this._byId[model.id] = model;
+    }
+
     if (this.accepts(model, options.index)) {
       if (already_here) {
         this.trigger('change', model, this, options);

--- a/test/spec.js
+++ b/test/spec.js
@@ -764,6 +764,26 @@ describe('Backbone.VirtualCollection', function () {
       assert(vc.length === 1);
 
     });
+    it('should be able to get model by ID if id present', function (done) {
+      var collection = new Backbone.Collection([{type: 'b'}]),
+      model,
+      stub,
+      vc = new VirtualCollection(collection);
+
+      Backbone.$ = {ajax: function () {}};
+      stub = sinon.stub(Backbone.$, 'ajax').yieldsTo('success', {id: 1});
+
+      function onSuccess() {
+        assert(vc.get(1).id === 1);
+        stub.restore();
+        done();
+      }
+
+      model = new Backbone.Model({type: 'a'});
+      vc.add(model);
+      model.url = '/fake-endpoint';
+      model.save({type: 'c'}, {success: onSuccess});
+    });
 
     it('should not trigger change events on models that are no longer in the virtual collection', function() {
       var collection = new Backbone.Collection([{type: 'z', testProperty: false}, {type: 'b'}]),


### PR DESCRIPTION
## What?
When you create a model in the browser you can find it in a Backbone collection by `cid` or by `model`. But you can not find by `id` until you save it in the server.

Ex.:
``` javascript
var model = new Backbone.Model();
var collection = new Backbone.Collection([model]);
// By model
collection.get(model); 
// => <model>
// By cid
collection.get(model.cid);
// => <model>
// By id
collection.get(model.id);
// => undefined

// Now we save the model in the server and we can find it by `id`
model.save();
//...after save it in the server...
collection.get(model.id);
// => <model>
```

Using a VirtualCollection I would expect the same behavior. But after save the model in the server I get undefined if I try to find it by `id`.

Ex.:
``` javascript
var model = new Backbone.Model();
var collection = new Backbone.Collection();
var vc = new Backbone.VirtualCollection(collection);
vc.add(model);

// After the model in the server I expect to find it by ID
model.save();
vc.get(model.id);
// => undefined :/
```