### PR TITLE
Only add model by id if model already in collection

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -103,12 +103,11 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (!model || !options) return; // ignore malformed arguments coming from custom events
     var already_here = this.get(model);
 
-    if (!this._byId[model.id] && model.id) {
-      this._byId[model.id] = model;
-    }
-
     if (this.accepts(model, options.index)) {
       if (already_here) {
+        if (!this._byId[model.id] && model.id) {
+          this._byId[model.id] = model;
+        }
         this.trigger('change', model, this, options);
       } else {
         this._indexAdd(model);

--- a/src/backbone.virtual-collection.js
+++ b/src/backbone.virtual-collection.js
@@ -94,12 +94,11 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (!model || !options) return; // ignore malformed arguments coming from custom events
     var already_here = this.get(model);
 
-    if (!this._byId[model.id] && model.id) {
-      this._byId[model.id] = model;
-    }
-
     if (this.accepts(model, options.index)) {
       if (already_here) {
+        if (!this._byId[model.id] && model.id) {
+          this._byId[model.id] = model;
+        }
         this.trigger('change', model, this, options);
       } else {
         this._indexAdd(model);


### PR DESCRIPTION
## What?
A couple of weeks ago I did a PR fixing a case where a model is saved in the server but it was not added to the VirtualCollection to be searched by server ID. 
Better explained here:
https://github.com/p3drosola/Backbone.VirtualCollection/pull/70

The fix was fine. But that `if` clause only has to be applied in case that model is already in the collection.

In this pull request I'm moving that `if` clause to the right place. 

## No test
In the previews PR I added a test for this case. It should work as before with this change.

## Sorry
I'm sorry because I did it wrong. I hope with this PR fix the problem.