### PR TITLE
Fixed not setting the model from the original collection

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -19,7 +19,7 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (options.comparator !== undefined) this.comparator = options.comparator;
     if (options.close_with) this.bindLifecycle(options.close_with, 'close'); // Marionette 1.*
     if (options.destroy_with) this.bindLifecycle(options.destroy_with, 'destroy'); // Marionette 2.*
-    if (!this.model) this.model = collection.model;
+    if (collection.model) this.model = collection.model;
 
     this.accepts = VirtualCollection.buildFilter(options.filter);
     this._rebuildIndex();

--- a/src/backbone.virtual-collection.js
+++ b/src/backbone.virtual-collection.js
@@ -10,7 +10,7 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     if (options.comparator !== undefined) this.comparator = options.comparator;
     if (options.close_with) this.bindLifecycle(options.close_with, 'close'); // Marionette 1.*
     if (options.destroy_with) this.bindLifecycle(options.destroy_with, 'destroy'); // Marionette 2.*
-    if (!this.model) this.model = collection.model;
+    if (collection.model) this.model = collection.model;
 
     this.accepts = VirtualCollection.buildFilter(options.filter);
     this._rebuildIndex();

--- a/test/spec.js
+++ b/test/spec.js
@@ -56,6 +56,15 @@ describe('Backbone.VirtualCollection', function () {
       assert.equal(calls, JSON.stringify([ 'destroy' ]));
       event_emitter.on.restore()
     });
+    it('should set the model from the collection', function () {
+      var vc, MyModel, MyCollection, my_model, my_collection;
+      MyModel = Backbone.Model.extend({foo: function () {return 'foo'; }});
+      MyCollection = Backbone.Collection.extend({model: MyModel});
+      my_collection = new MyCollection([{id: 1, foo: 'bar'}]);
+      vc = new VirtualCollection(my_collection);
+      my_model = new vc.model();
+      assert.equal(my_model.foo(), 'foo');
+    });
   });
 
   describe('#model', function () {


### PR DESCRIPTION
Before this fix, Backbone.VC was never setting the model from the passed collection. Backbone.Collection always sets a plain Model as default https://github.com/jashkenas/backbone/blob/master/backbone.js#L782 and Backbone.VC inherits from that https://github.com/p3drosola/Backbone.VirtualCollection/blob/master/backbone.virtual-collection.js#L13. 