### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "backbone-virtual-collection",
   "description": "Use Backbone.Marionette CollectionViews on a subset of a Backbone collection",
   "version": "0.6.8",
+  "license": "MIT",
   "main": "backbone.virtual-collection.js",
   "keywords": [
     "backbone",


### PR DESCRIPTION
npm gives a warning when not using the `license` parameter, and this also probably fixes #76.