### PR TITLE
Trigger collection update in _onChange()

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -133,6 +133,7 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
         , options_clone = _.clone(options);
         options_clone.index = i;
         this.trigger('remove', model, this, options_clone);
+        this.trigger('update', this, { changes: { removed: [model] } });
       }
     }
   },


### PR DESCRIPTION
Hi guys,

I found a bug on `Backbone.VirtualCollection` during a migration from Marionette 2 to Marionette 3.

I discovered a case where the collection `update` event should be triggered after a model `change` event if it doesn't pass through filter (`this.accepts()`) and `already_here` is `true`.

This is a partial fix, just for the 'remove case', but I think that maybe something similar should be done pass through filter (`this.accepts()`) too.