### PR TITLE
Trigger sort on add

### DIFF
--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -102,7 +102,7 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     this._indexAdd(model);
     this.listenTo(model, 'all', this._onAllEvent);
     this.trigger('add', model, this, options);  
-    if (this.comparator) {
+    if (this.comparator !== undefined) {
       this.trigger('sort', this, options);
     }
   },

--- a/backbone.virtual-collection.js
+++ b/backbone.virtual-collection.js
@@ -102,6 +102,9 @@ var VirtualCollection = Backbone.VirtualCollection = Backbone.Collection.extend(
     this._indexAdd(model);
     this.listenTo(model, 'all', this._onAllEvent);
     this.trigger('add', model, this, options);  
+    if (this.comparator) {
+      this.trigger('sort', this, options);
+    }
   },
 
   _onRemove: function (model, collection, options) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -674,6 +674,46 @@ describe('Backbone.VirtualCollection', function () {
         collection.first().trigger('foo');
       });
     });
+    it('should trigger a `sort` event when a comparator is set on the virtual collection and a model matching the filter is added to the base collection', function () {
+      var collection = new Backbone.Collection([{ type: 'a', sort: 'a' }, { type: 'b', sort: 'b' }]);
+      var sort = sinon.stub();
+      var vc = new VirtualCollection(collection, {
+          filter: {type: 'a'},
+          comparator: 'sort'
+      });
+
+      vc.on('sort', sort);
+      collection.add({ type: 'a', sort:'c' });
+
+      assert(sort.called);
+    });
+    it('should trigger a `sort` event when a comparator is set on the virtual collection and a model in the base collection is updated to match the filter', function () {
+      var modelToUpdate = new Backbone.Model({ type: 'b', sort: 'b' });
+      var collection = new Backbone.Collection([{ type: 'a', sort: 'a' }, modelToUpdate]);
+      var sort = sinon.stub();
+      var vc = new VirtualCollection(collection, {
+          filter: { type: 'a' },
+          comparator: 'sort'
+      });
+
+      vc.on('sort', sort);
+      modelToUpdate.set('type', 'a');
+
+      assert(sort.called);
+    });
+    it('should not trigger a `sort` event when a comparator is set on the virtual collection and a model not matching the filter is added to the base collection', function () {
+      var collection = new Backbone.Collection([{ type: 'a', sort: 'a' }, { type: 'b', sort: 'b' }]);
+      var sort = sinon.stub();
+      var vc = new VirtualCollection(collection, {
+          filter: { type: 'a' },
+          comparator: 'sort'
+      });
+
+      vc.on('sort', sort);
+      collection.add({ type: 'b', sort: 'c' });
+
+      assert(!sort.called);
+    });
   });
   describe('accepts & get', function () {
     it('should not call accepts() when iterating over the virtual collection', function () {


### PR DESCRIPTION
This PR addresses #102 by triggering sort when a base collection model is added or updated in a way that causes it to match an associated virtual collection's filter so that "adding" items to the virtual collection mimics the behavior of adding items to a Backbone collection (see backbone.js v1.3.3 lines [910](https://github.com/jashkenas/backbone/blob/1.3.3/backbone.js#L910) and [925](https://github.com/jashkenas/backbone/blob/1.3.3/backbone.js#L925)).

A few additional notes:
- Sort events from the base collection are not currently re-triggered in the virtual collection unless no comparator is set on the virtual collection (see [backbone.virtual-collection.js v0.6.15 line 75](https://github.com/p3drosola/Backbone.VirtualCollection/blob/v0.6.15/backbone.virtual-collection.js#L75)), so there should be no circumstances under which this causes duplicate sort events to be fired
- This change doesn't check option sort for false (see [backbone.js v1.3.3 line 852](https://github.com/jashkenas/backbone/blob/1.3.3/backbone.js#L852)) because the existing sorting code currently doesn't (might be worth updating in some future PR, but I'd rather not handle it in this one)
- This change doesn't trigger sort on change of sortable attributes because as far as I can tell Backbone does not automatically sort on change under any circumstances
- This change does trigger sort on a change of filterable attributes that cause the filter conditions to be met when they weren't previously because that "adds" the item to the virtual collection
- This change doesn't trigger sort on update in the case of merged models with changed comparator properties because the existing sorting code currently doesn't handle sorting on update (Backbone's logic there is a bit weird anyway - it only automatically performs sorting if the comparator is a string property name per code around [backbone.js v1.3.3 line 870](https://github.com/jashkenas/backbone/blob/1.3.3/backbone.js#L870))
- As far as I can tell Backbone triggers sort even if all new items end up being sorted to the end of the collection, which is nice for keeping this change simple 😄 